### PR TITLE
Update README.md to include a new utility/wrapper enabling Pug templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ To contribute, fork this repository, add your amazing entry and send us a PR. Se
 * [picostyle/picostyle](https://github.com/picostyle/picostyle) - 0.3 KB CSS-in-JS library for use with Hyperapp & Picodom.
 * [shershen08/single-spa-hyperapp](https://github.com/shershen08/single-spa-hyperapp) - wrapper for using Hyperapp within single-spa apps
 * [elisherer/hyperapp-forms](https://github.com/elisherer/hyperapp-forms) - Form state management library (similiar to redux-form)
+* [johnkazer/hyperapp-pug](https://github.com/johnkazer/hyperapp-pug) - A wrapper for Hyperapp which enables you to use Pug templates rather than JSX or hyperscript.
 
 ## Testing
 


### PR DESCRIPTION
Add a new [utility](https://github.com/johnkazer/hyperapp-pug) for supporting Pug templates rather than JSX or hyperscript. Helps make Hyperapp that bit more flexible and accessible.